### PR TITLE
Feat/#7 일기장 수정 (#8)

### DIFF
--- a/replace/src/main/kotlin/com/app/replace/application/DiaryService.kt
+++ b/replace/src/main/kotlin/com/app/replace/application/DiaryService.kt
@@ -1,23 +1,54 @@
 package com.app.replace.application
 
 import com.app.replace.domain.*
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.fasterxml.jackson.annotation.JsonValue
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 
 @Service
+@Transactional
 class DiaryService(
     private val diaryRepository : DiaryRepository,
     private val imageService: ImageService
 ) {
     fun createDiary(title: String, content: String, shareScope: String, imageURLs: List<String>) : Long {
-        val diary = diaryRepository.save(Diary(Title(title), Content(content), imageURLs, ShareScope.valueOf(shareScope)))
+        val diary = diaryRepository.save(
+            Diary(
+                Title(title),
+                Content(content),
+                Place("루터회관", "서울 송파구 올림픽로35다길 42"), // FIXME : 요청에서 장소 정보를 받도록 수정해야 한다
+                ImageURL.from(imageURLs),
+                ShareScope.valueOf(shareScope)
+            )
+        )
         return diary.id ?: throw IllegalArgumentException("저장한 일기장의 식별자를 찾을 수 없습니다.")
     }
 
-    fun uploadImages(images: List<MultipartFile>) : List<String> {
+    fun updateDiary(diaryId: Long, title: String, content: String, shareScope: String, imageURLs: List<String>) {
+        val diary =
+            diaryRepository.findByIdOrNull(diaryId) ?: throw IllegalArgumentException("id에 해당하는 일기장을 찾을 수 없습니다.")
 
+        diary.update(Diary(
+            Title(title),
+            Content(content),
+            Place("루터회관", "서울 송파구 올림픽로35다길 42"), // FIXME : 요청에서 장소 정보를 받도록 수정해야 한다
+            ImageURL.from(imageURLs),
+            ShareScope.valueOf(shareScope)
+        ))
+    }
+
+    @Transactional(readOnly = true)
+    fun loadSingleDiary(id: Long): SingleDiaryRecord {
+        val diary = diaryRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("id에 해당하는 일기장을 찾을 수 없습니다.")
+        return SingleDiaryRecord.from(diary)
+    }
+
+    fun uploadImages(images: List<MultipartFile>) : List<String> {
         val imageRequests = images.map { image ->
             ImageUploadingRequest(
                 image,
@@ -29,3 +60,34 @@ class DiaryService(
         return imageService.uploadImage(imageRequests)
     }
 }
+
+data class SingleDiaryRecord(
+    val images: List<ImageURLRecord>,
+    val place: Place,
+    val createdAt: String,
+    val writer: Writer,
+    @JsonUnwrapped val title: Title,
+    @JsonUnwrapped val content: Content
+) {
+    companion object {
+        fun from(diary: Diary): SingleDiaryRecord {
+            return SingleDiaryRecord(
+                diary.imageURLs
+                    .map { imageURL -> ImageURLRecord(imageURL.url) }
+                    .toList(),
+                diary.place,
+                diary.createdAt.toString(),
+                Writer(
+                    "https://replace-s3.s3.ap-northeast-2.amazonaws.com/client/profile/replace-default-profile-image.png",
+                    "요아소비"
+                ), // FIXME : 작성자 정보를 저장할 수 있어야 한다
+                diary.title,
+                diary.content
+            )
+        }
+    }
+}
+
+data class Writer(val profileImage: String, val nickname: String)
+
+data class ImageURLRecord(@JsonValue val imageURL: String)

--- a/replace/src/main/kotlin/com/app/replace/configuration/JPAConfig.kt
+++ b/replace/src/main/kotlin/com/app/replace/configuration/JPAConfig.kt
@@ -1,0 +1,9 @@
+package com.app.replace.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@Configuration
+@EnableJpaAuditing
+class JPAConfig {
+}

--- a/replace/src/main/kotlin/com/app/replace/domain/Content.kt
+++ b/replace/src/main/kotlin/com/app/replace/domain/Content.kt
@@ -15,4 +15,21 @@ class Content(_content: String) {
         require(_content.length <= CONTENT_MAX_LENGTH) { "일기장의 내용은 ${CONTENT_MAX_LENGTH}자를 넘을 수 없습니다."}
         this.content = _content
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Content
+
+        return content == other.content
+    }
+
+    override fun hashCode(): Int {
+        return content.hashCode()
+    }
+
+    override fun toString(): String {
+        return "Content(content='$content')"
+    }
 }

--- a/replace/src/main/kotlin/com/app/replace/domain/ImageURL.kt
+++ b/replace/src/main/kotlin/com/app/replace/domain/ImageURL.kt
@@ -1,0 +1,36 @@
+package com.app.replace.domain
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class ImageURL(
+    val url: String
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null
+
+    companion object {
+        fun from(imageURLs: List<String>): List<ImageURL> {
+            return imageURLs
+                .map { imageURL -> ImageURL(imageURL) }
+                .toList()
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ImageURL
+
+        return url == other.url
+    }
+
+    override fun hashCode(): Int {
+        return url.hashCode()
+    }
+}

--- a/replace/src/main/kotlin/com/app/replace/domain/Place.kt
+++ b/replace/src/main/kotlin/com/app/replace/domain/Place.kt
@@ -1,0 +1,33 @@
+package com.app.replace.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+class Place(_spotName: String, _roadAddress: String) {
+    @Column
+    val spotName: String
+    @Column
+    val roadAddress: String
+
+    init {
+        spotName = _spotName
+        roadAddress = _roadAddress
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Place
+
+        if (spotName != other.spotName) return false
+        return roadAddress == other.roadAddress
+    }
+
+    override fun hashCode(): Int {
+        var result = spotName.hashCode()
+        result = 31 * result + roadAddress.hashCode()
+        return result
+    }
+}

--- a/replace/src/main/kotlin/com/app/replace/domain/TemporalRecord.kt
+++ b/replace/src/main/kotlin/com/app/replace/domain/TemporalRecord.kt
@@ -1,0 +1,22 @@
+package com.app.replace.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class TemporalRecord {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    var createdAt: LocalDateTime = LocalDateTime.MIN
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    var modifiedAt: LocalDateTime = LocalDateTime.MIN
+}
+

--- a/replace/src/main/kotlin/com/app/replace/domain/Title.kt
+++ b/replace/src/main/kotlin/com/app/replace/domain/Title.kt
@@ -15,4 +15,17 @@ class Title(_title: String) {
         require(_title.length <= TITLE_MAX_LENGTH) { "일기장 제목이 ${TITLE_MAX_LENGTH}자를 초과하였습니다."}
         this.title = _title
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Title
+
+        return title == other.title
+    }
+
+    override fun hashCode(): Int {
+        return title.hashCode()
+    }
 }

--- a/replace/src/main/kotlin/com/app/replace/ui/DiaryController.kt
+++ b/replace/src/main/kotlin/com/app/replace/ui/DiaryController.kt
@@ -1,6 +1,7 @@
 package com.app.replace.ui
 
 import com.app.replace.application.DiaryService
+import com.app.replace.application.SingleDiaryRecord
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
@@ -13,7 +14,7 @@ import java.net.URI
 class DiaryController(val diaryService: DiaryService) {
 
     @PostMapping
-    fun createDiary(@RequestBody createDiaryRequest: CreateDiaryRequest) : ResponseEntity<Long> {
+    fun createDiary(@RequestBody createDiaryRequest: CreateDiaryRequest): ResponseEntity<Long> {
         val diaryId = diaryService.createDiary(
             createDiaryRequest.title,
             createDiaryRequest.content,
@@ -25,11 +26,29 @@ class DiaryController(val diaryService: DiaryService) {
     }
 
     @PostMapping("/images")
-    fun uploadImages(@ModelAttribute imageUploadingRequest: ImageUploadingRequest) : ResponseEntity<ImageUploadingResponse> {
+    fun uploadImages(@ModelAttribute imageUploadingRequest: ImageUploadingRequest): ResponseEntity<ImageUploadingResponse> {
         val imageUrls = diaryService.uploadImages(imageUploadingRequest.images)
         return ResponseEntity
             .status(HttpStatusCode.valueOf(HttpStatus.CREATED.value()))
             .body(ImageUploadingResponse(imageUrls))
+    }
+
+    @GetMapping("/{diaryId}")
+    fun loadSingleDiary(@PathVariable diaryId: Long): ResponseEntity<SingleDiaryRecord> {
+        val diary = diaryService.loadSingleDiary(diaryId)
+        return ResponseEntity.ok(diary)
+    }
+
+    @PutMapping("/{diaryId}")
+    @ResponseStatus(HttpStatus.OK)
+    fun updateDiary(@PathVariable diaryId: Long, @ModelAttribute createDiaryRequest: CreateDiaryRequest) {
+        diaryService.updateDiary(
+            diaryId,
+            createDiaryRequest.title,
+            createDiaryRequest.content,
+            createDiaryRequest.shareScope,
+            createDiaryRequest.images
+        )
     }
 }
 

--- a/replace/src/test/kotlin/com/app/replace/application/DiaryServiceTest.kt
+++ b/replace/src/test/kotlin/com/app/replace/application/DiaryServiceTest.kt
@@ -1,16 +1,23 @@
 package com.app.replace.application
 
+import com.app.replace.domain.Content
 import com.app.replace.domain.DiaryRepository
+import com.app.replace.domain.ShareScope
+import com.app.replace.domain.Title
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.support.TransactionTemplate
 
 @DataJpaTest
 @Import(DiaryService::class)
@@ -42,5 +49,141 @@ class DiaryServiceTest(
         Assertions.assertThat(diaries.get(0))
             .extracting("imageURLs").asList()
             .hasSize(3)
+    }
+
+    @Nested
+    @DisplayName("게시글을 수정할 때")
+    inner class UpdatingDiary(
+        @Autowired val transactionTemplate: TransactionTemplate,
+        @Autowired val entityManager: EntityManager
+    ) {
+        @Test
+        @DisplayName("제목을 수정할 수 있다.")
+        fun updateTitle() {
+            val diaryId = createDiary()
+            transactionTemplate.execute {
+                diaryService.updateDiary(
+                    diaryId,
+                    "케로의 방명록",
+                    "케로는 이리내와 나란히 햄버거를 먹었다. 햄버거가 생각보다 맛있어 케로 혼자 4개를 먹었다.",
+                    "US",
+                    listOf(
+                        "https://mybucket.s3.amazonaws.com/images/photo1.jpg",
+                        "https://s3-us-west-2.amazonaws.com/mybucket/images/pic2.png",
+                        "https://my-s3-bucket.s3.eu-central-1.amazonaws.com/photos/image3.jpg"
+                    )
+                )
+            }
+            entityManager.flush()
+            entityManager.clear()
+
+            val result = diaryRepository.findByIdOrNull(diaryId) ?: fail()
+            result.title shouldBe Title("케로의 방명록")
+        }
+
+        @Test
+        @DisplayName("내용을 수정할 수 있다.")
+        fun contentTitle() {
+            val diaryId = createDiary()
+            transactionTemplate.execute {
+                diaryService.updateDiary(
+                    diaryId,
+                    "케로의 일기",
+                    "케로는 롯데월드에 갔다. 그 곳에서 이리내와 결별했다.",
+                    "US",
+                    listOf(
+                        "https://mybucket.s3.amazonaws.com/images/photo1.jpg",
+                        "https://s3-us-west-2.amazonaws.com/mybucket/images/pic2.png",
+                        "https://my-s3-bucket.s3.eu-central-1.amazonaws.com/photos/image3.jpg"
+                    )
+                )
+            }
+            entityManager.flush()
+            entityManager.clear()
+
+            val result = diaryRepository.findByIdOrNull(diaryId) ?: fail()
+            result.content shouldBe Content("케로는 롯데월드에 갔다. 그 곳에서 이리내와 결별했다.")
+        }
+
+        @Test
+        @DisplayName("이미지를 추가 저장할 수 있다.")
+        fun addImage() {
+            val diaryId = createDiary()
+            diaryService.updateDiary(
+                diaryId,
+                "케로의 일기",
+                "케로는 이리내와 나란히 햄버거를 먹었다. 햄버거가 생각보다 맛있어 케로 혼자 4개를 먹었다.",
+                "US",
+                listOf(
+                    "https://mybucket.s3.amazonaws.com/images/photo1.jpg",
+                    "https://s3-us-west-2.amazonaws.com/mybucket/images/pic2.png",
+                    "https://my-s3-bucket.s3.eu-central-1.amazonaws.com/photos/image3.jpg",
+                    "https://additional.s3.eu-central-1.amazonaws.com/photos/image3.jpg",
+                )
+            )
+            entityManager.flush()
+            entityManager.clear()
+
+            val result = diaryRepository.findByIdOrNull(diaryId) ?: fail()
+            result.imageURLs shouldHaveSize 4
+        }
+
+        @Test
+        @DisplayName("기존에 저장된 이미지를 삭제할 수 있다.")
+        fun removeImage() {
+            val diaryId = createDiary()
+            diaryService.updateDiary(
+                diaryId,
+                "케로의 일기",
+                "케로는 이리내와 나란히 햄버거를 먹었다. 햄버거가 생각보다 맛있어 케로 혼자 4개를 먹었다.",
+                "US",
+                listOf(
+                    "https://mybucket.s3.amazonaws.com/images/photo1.jpg",
+                )
+            )
+            entityManager.flush()
+            entityManager.clear()
+
+            val result = diaryRepository.findByIdOrNull(diaryId) ?: fail()
+            result.imageURLs shouldHaveSize 1
+        }
+
+        @Test
+        @DisplayName("동시에 다 바꿀 수 있다.")
+        fun updateAll() {
+            val diaryId = createDiary()
+            diaryService.updateDiary(
+                diaryId,
+                "케로의 방명록",
+                "케로는 오늘 아무것도 하지 않았다.",
+                ShareScope.ALL.name,
+                listOf(
+                    "https://mybucket.s3.amazonaws.com/images/photo1.jpg",
+                )
+            )
+            entityManager.flush()
+            entityManager.clear()
+
+            val result = diaryRepository.findByIdOrNull(diaryId) ?: fail()
+            result.title shouldBe Title("케로의 방명록")
+            result.content shouldBe Content("케로는 오늘 아무것도 하지 않았다.")
+            result.shareScope shouldBe ShareScope.ALL
+            result.imageURLs shouldHaveSize 1
+        }
+
+        private fun createDiary(): Long {
+            val diary = diaryService.createDiary(
+                "케로의 일기",
+                "케로는 이리내와 나란히 햄버거를 먹었다. 햄버거가 생각보다 맛있어 케로 혼자 4개를 먹었다.",
+                "US",
+                listOf(
+                    "https://mybucket.s3.amazonaws.com/images/photo1.jpg",
+                    "https://s3-us-west-2.amazonaws.com/mybucket/images/pic2.png",
+                    "https://my-s3-bucket.s3.eu-central-1.amazonaws.com/photos/image3.jpg"
+                )
+            )
+            entityManager.flush()
+            return diary
+        }
     }
 }


### PR DESCRIPTION
* Feat/#5 일기장 상세조회 (#6)

* feat: Diary에 주소 상태 추가

* feat: Diary에 생성일, 수정일 상태 추가

* feat: Diary 단건 조회 기능과 API 구현

* fix: DTO 속 VO 필드를 unwrapping

* feat: 일기장 수정 기능 구현

* feat: 일기장 수정 API 구현