### PR TITLE
fix: 좌표 응답 포맷으로 BigDecimal 대신 String 사용

### DIFF
--- a/replace/src/main/kotlin/com/app/replace/domain/PlaceWithCoordinate.kt
+++ b/replace/src/main/kotlin/com/app/replace/domain/PlaceWithCoordinate.kt
@@ -1,3 +1,5 @@
 package com.app.replace.domain
 
-data class PlaceWithCoordinate(val spotName: String, val coordinate: Coordinate)
+import com.app.replace.ui.response.CoordinateResponse
+
+data class PlaceWithCoordinate(val spotName: String, val coordinate: CoordinateResponse)

--- a/replace/src/main/kotlin/com/app/replace/infrastructure/KakaoPlaceInformationByKeyword.kt
+++ b/replace/src/main/kotlin/com/app/replace/infrastructure/KakaoPlaceInformationByKeyword.kt
@@ -2,6 +2,7 @@ package com.app.replace.infrastructure
 
 import com.app.replace.domain.Coordinate
 import com.app.replace.domain.PlaceWithCoordinate
+import com.app.replace.ui.response.CoordinateResponse
 import java.math.BigDecimal
 
 data class KakaoPlaceInformationByKeyword(
@@ -12,9 +13,11 @@ data class KakaoPlaceInformationByKeyword(
         return documents.map { document ->
             PlaceWithCoordinate(
                 document.get("place_name") ?: "unknown",
-                Coordinate(
-                    BigDecimal(document.get("x")),
-                    BigDecimal((document.get("y")))
+                CoordinateResponse.from(
+                    Coordinate(
+                        BigDecimal(document.get("x")),
+                        BigDecimal((document.get("y")))
+                    )
                 ),
             )
         }.toList()

--- a/replace/src/main/kotlin/com/app/replace/ui/response/CoordinatesResponse.kt
+++ b/replace/src/main/kotlin/com/app/replace/ui/response/CoordinatesResponse.kt
@@ -1,7 +1,6 @@
 package com.app.replace.ui.response
 
 import com.app.replace.domain.Coordinate
-import java.math.BigDecimal
 
 data class CoordinatesResponse(val diaryCoordinates: List<CoordinateResponse>) {
     companion object {
@@ -12,12 +11,15 @@ data class CoordinatesResponse(val diaryCoordinates: List<CoordinateResponse>) {
 }
 
 data class CoordinateResponse(
-    val longitude: BigDecimal,
-    val latitude: BigDecimal
+    val longitude: String,
+    val latitude: String
 ) {
     companion object {
         fun from(coordinate: Coordinate): CoordinateResponse {
-            return CoordinateResponse(coordinate.longitude, coordinate.latitude)
+            return CoordinateResponse(
+                coordinate.longitude.toPlainString(),
+                coordinate.latitude.toPlainString()
+            )
         }
     }
 }

--- a/replace/src/test/kotlin/com/app/replace/ui/MainPageControllerTest.kt
+++ b/replace/src/test/kotlin/com/app/replace/ui/MainPageControllerTest.kt
@@ -8,6 +8,7 @@ import com.app.replace.application.response.SimpleUserProfile
 import com.app.replace.domain.Coordinate
 import com.app.replace.domain.Place
 import com.app.replace.domain.PlaceWithCoordinate
+import com.app.replace.ui.response.CoordinateResponse
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import org.hamcrest.Matchers.*
@@ -48,14 +49,17 @@ class MainPageControllerTest(
                 10
             )
         } returns listOf(
-            PlaceWithCoordinate("한국루터회관", Coordinate(BigDecimal("127.10305689374302"), BigDecimal("37.5152439826822"))),
+            PlaceWithCoordinate(
+                "한국루터회관",
+                CoordinateResponse.from(Coordinate(BigDecimal("127.10305689374302"), BigDecimal("37.5152439826822")))
+            ),
             PlaceWithCoordinate(
                 "한국루터회관 주차장",
-                Coordinate(BigDecimal("127.102995850174"), BigDecimal("37.5152710660296"))
+                CoordinateResponse.from(Coordinate(BigDecimal("127.102995850174"), BigDecimal("37.5152710660296")))
             ),
             PlaceWithCoordinate(
                 "한국루터회관 전기차충전소",
-                Coordinate(BigDecimal("127.103069349741"), BigDecimal("37.5152538828512"))
+                CoordinateResponse.from(Coordinate(BigDecimal("127.103069349741"), BigDecimal("37.5152538828512")))
             )
         )
 
@@ -67,16 +71,16 @@ class MainPageControllerTest(
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isOk)
             .andExpect(jsonPath("places[0].spotName", equalTo("한국루터회관")))
-            .andExpect(jsonPath("places[0].coordinate.longitude", equalTo(127.10305689374302)))
-            .andExpect(jsonPath("places[0].coordinate.latitude", equalTo(37.5152439826822)))
+            .andExpect(jsonPath("places[0].coordinate.longitude", equalTo("127.10305689374302")))
+            .andExpect(jsonPath("places[0].coordinate.latitude", equalTo("37.5152439826822")))
 
             .andExpect(jsonPath("places[1].spotName", equalTo("한국루터회관 주차장")))
-            .andExpect(jsonPath("places[1].coordinate.longitude", equalTo(127.102995850174)))
-            .andExpect(jsonPath("places[1].coordinate.latitude", equalTo(37.5152710660296)))
+            .andExpect(jsonPath("places[1].coordinate.longitude", equalTo("127.102995850174")))
+            .andExpect(jsonPath("places[1].coordinate.latitude", equalTo("37.5152710660296")))
 
             .andExpect(jsonPath("places[2].spotName", equalTo("한국루터회관 전기차충전소")))
-            .andExpect(jsonPath("places[2].coordinate.longitude", closeTo(127.103069349741, 0.000001)))
-            .andExpect(jsonPath("places[2].coordinate.latitude", closeTo(37.5152538828512, 0.000001)));
+            .andExpect(jsonPath("places[2].coordinate.longitude", equalTo("127.103069349741")))
+            .andExpect(jsonPath("places[2].coordinate.latitude", equalTo("37.5152538828512")))
     }
 
     @Test


### PR DESCRIPTION
좌표 정보를 응답하는 객체로 Coordinate(내부에 BigDecimal을 갖고 있음) 대신 CoordinateResponse(내부에 String을 갖고 있음)을 사용하도록 변경합니다.